### PR TITLE
[PRM-FixTTL] - Use Mongo date time formatters for insertions

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -40,12 +40,14 @@ class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig)
     else servicesConfig.baseUrl("sdes")
   }
 
-  val sdesUrl: String = sdesBaseUrl + s"/notification/fileready"
+  lazy val sdesUrl: String = sdesBaseUrl + s"/notification/fileready"
 
   val auditingEnabled: Boolean = config.get[Boolean]("auditing.enabled")
   val graphiteHost: String     = config.get[String]("microservice.metrics.graphite.host")
 
-  val notificationTtl:Long = config.get[Long]("mongo-config.ttlHours")
+  lazy val notificationTtl: Long = config.get[Long]("mongo-config.ttlHours")
 
   def isFeatureSwitchEnabled(featureSwitch: FeatureSwitch): Boolean = config.get[Boolean](featureSwitch.name)
+
+  lazy val replaceMongoIndexes: Boolean = config.get[Boolean]("mongo-config.replaceIndexes")
 }

--- a/app/models/SDESNotificationRecord.scala
+++ b/app/models/SDESNotificationRecord.scala
@@ -17,21 +17,24 @@
 package models
 
 import java.time.LocalDateTime
-
 import models.notification.{RecordStatusEnum, SDESNotification}
 import play.api.libs.json._
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
+
+import java.time.temporal.ChronoUnit
 
 
 case class SDESNotificationRecord(reference: String,
-                                    status: RecordStatusEnum.Value = RecordStatusEnum.PENDING,
+                                  status: RecordStatusEnum.Value = RecordStatusEnum.PENDING,
                                   numberOfAttempts: Int = 0,
                                   createdAt: LocalDateTime = LocalDateTime.now(),
                                   updatedAt: LocalDateTime = LocalDateTime.now(),
                                   nextAttemptAt: LocalDateTime = LocalDateTime.now(),
-                                  notification: SDESNotification)
+                                  notification: SDESNotification
+                                 )
 
-object SDESNotificationRecord {
-
+object SDESNotificationRecord extends MongoJavatimeFormats {
+  implicit val dateFormat: Format[LocalDateTime] = localDateTimeFormat
   implicit val mongoFormats: OFormat[SDESNotificationRecord] = Json.format[SDESNotificationRecord]
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -144,7 +144,8 @@ microservice {
 }
 
 mongo-config {
-    ttlHours = 24
+    ttlHours = 1
+    replaceIndexes = true
 }
 
 schedules {

--- a/it/repositories/FileNotificationRepositoryISpec.scala
+++ b/it/repositories/FileNotificationRepositoryISpec.scala
@@ -23,9 +23,11 @@ import org.mongodb.scala.result.DeleteResult
 import org.scalatest.matchers.should.Matchers._
 import play.api.test.Helpers._
 import services.NotificationMongoService
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 import utils.IntegrationSpecCommonBase
 
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 import scala.concurrent.Future
 
 class FileNotificationRepositoryISpec extends IntegrationSpecCommonBase {
@@ -104,7 +106,7 @@ class FileNotificationRepositoryISpec extends IntegrationSpecCommonBase {
 
   "updateFileNotification" should {
     "update the file notification with the new fields for SENT notifications" in new Setup {
-      lazy val dateTimeNow: LocalDateTime = LocalDateTime.now()
+      lazy val dateTimeNow: LocalDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS)
       val notificationRecordInPending: SDESNotificationRecord = SDESNotificationRecord(
         reference = "ref",
         status = RecordStatusEnum.PENDING,

--- a/it/services/SendFileNotificationsToSDESServiceISpec.scala
+++ b/it/services/SendFileNotificationsToSDESServiceISpec.scala
@@ -29,6 +29,7 @@ import utils.Logger.logger
 import utils.{IntegrationSpecCommonBase, LogCapturing}
 
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 import scala.concurrent.duration.DurationInt
 
 class SendFileNotificationsToSDESServiceISpec extends IntegrationSpecCommonBase with LogCapturing {
@@ -49,7 +50,7 @@ class SendFileNotificationsToSDESServiceISpec extends IntegrationSpecCommonBase 
       name = "ame", location = "someUrl", checksum = SDESChecksum(algorithm = "sha", value = "256"), size = 256, properties = Seq.empty[SDESProperties]
     ), audit = SDESAudit("file 1"))
 
-  lazy val dateTimeOfNow: LocalDateTime = LocalDateTime.now()
+  lazy val dateTimeOfNow: LocalDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS)
 
   val notificationRecord: SDESNotificationRecord = SDESNotificationRecord(
     reference = "ref",


### PR DESCRIPTION
Hotfix to test TTL works properly, TTL reduced to 1hr temporarily
Switch added to toggle replacing indexes on existing DB